### PR TITLE
Refactor documentation structure and update references

### DIFF
--- a/docs/api/mask.md
+++ b/docs/api/mask.md
@@ -1,0 +1,3 @@
+# Masking Module
+
+::: spectralmatch.mask

--- a/docs/api/masking.md
+++ b/docs/api/masking.md
@@ -1,3 +1,0 @@
-# Masking Module
-
-::: spectralmatch.masking

--- a/docs/api/match.md
+++ b/docs/api/match.md
@@ -1,0 +1,3 @@
+# Process Module
+
+::: spectralmatch.match.global_regression

--- a/docs/api/process.md
+++ b/docs/api/process.md
@@ -1,3 +1,0 @@
-# Process Module
-
-::: spectralmatch.process

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,3 @@
+# Common Utils Module
+
+::: spectralmatch.utils

--- a/docs/api/utils_common.md
+++ b/docs/api/utils_common.md
@@ -1,3 +1,0 @@
-# Common Utils Module
-
-::: spectralmatch.utils.utils_common

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,1 @@
-# SpectralMatch Documentation
-
-...
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,15 +36,15 @@ markdown_extensions:
 nav:
     - Home: index.md
     - Installation: installation.md
-    - Changelog: https://github.com/cankanoa/spectralmatch/releases
-    - Report Issues: https://github.com/cankanoa/spectralmatch/issues
+    - Changelog: https://github.com/spectralmatch/spectralmatch/releases
+    - Report Issues: https://github.com/spectralmatch/spectralmatch/issues
     - Examples:
-        - examples/getting-started.ipynb
-        - examples/example.py
+#        - examples/getting-started.ipynb
+        - examples/example_global_to_local.py
     - API Reference:
-        - masking module: api/masking.md
-        - process module: api/process.md
-        - utils module: api/utils_common.md
+        - mask module: api/mask.md
+        - match module: api/match.md
+        - utils module: api/utils.md
 
 extra_css:
     - docs/overrides/custom.css


### PR DESCRIPTION
Reorganized API documentation by renaming and splitting files for better clarity: `masking` to `mask`, `process` to `match`, and `utils_common` to `utils`. Updated `mkdocs.yml` navigation links, fixed repository references, and linked the main index to the README file.