### PR TITLE
Fixed bug where reference block means on the edges of images are calculated incorrectly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Example image
-/docs/examples/example_data/Output
+/docs/examples/example_data/*
+!/docs/examples/example_data/Input/
 *.gpkg-shm
 *.gpkg-wal
 

--- a/docs/examples/example_global_to_local.py
+++ b/docs/examples/example_global_to_local.py
@@ -10,8 +10,8 @@ working_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ex
 vector_mask_path = working_directory + "/Input/Masks.gpkg"
 
 input_folder = os.path.join(working_directory, "Input")
-global_folder = os.path.join(working_directory, "Output/GlobalMatch")
-local_folder = os.path.join(working_directory, "Output/LocalMatch")
+global_folder = os.path.join(working_directory, "GlobalMatch")
+local_folder = os.path.join(working_directory, "LocalMatch")
 
 # -------------------- Global histogram matching
 input_image_paths_array = [os.path.join(input_folder, f) for f in os.listdir(input_folder) if f.lower().endswith(".tif")]
@@ -23,33 +23,35 @@ matched_global_images_paths = global_regression(
     custom_std_factor = 1,
     # vector_mask_path=vector_mask_path,
     debug_mode=False,
-    tile_width_and_height_tuple=(512, 512),
+    window_size=(512, 512),
     parallel=True,
     )
 
 merge_rasters(
     matched_global_images_paths, # Rasters are layered with the last ones on top
-    os.path.join(working_directory, "Output/GlobalMatch/MatchedGlobalImages.tif"),
+    os.path.join(working_directory, "MatchedGlobalImages.tif"),
     tile_width_and_height_tuple=(512, 512),
     )
 
 # -------------------- Local histogram matching
-global_image_paths_array = [os.path.join(f"{global_folder}/Images", f) for f in os.listdir(f"{global_folder}/Images") if f.lower().endswith(".tif")]
+global_image_paths_array = [os.path.join(global_folder, f) for f in os.listdir(global_folder) if f.lower().endswith(".tif")]
 
 matched_local_images_paths = local_block_adjustment(
     global_image_paths_array,
     local_folder,
     target_blocks_per_image=100,
-    projection="EPSG:6635",
-    debug_mode=False,
-    tile_width_and_height_tuple=(512, 512),
+    debug_mode=True,
+    window_size="block",
     parallel=True,
     )
 
 merge_rasters(
     matched_local_images_paths, # Rasters are layered with the last ones on top
-    os.path.join(working_directory, "Output/LocalMatch/MatchedLocalImages.tif"),
+    os.path.join(working_directory, "MatchedLocalImages.tif"),
     tile_width_and_height_tuple=(512, 512),
     )
 
 print("Done with global and local histogram matching")
+
+# Statistics
+# To visually see the difference make sure to merge input images so that their histograms match

--- a/docs/examples/example_global_to_local.py
+++ b/docs/examples/example_global_to_local.py
@@ -39,9 +39,9 @@ global_image_paths_array = [os.path.join(global_folder, f) for f in os.listdir(g
 matched_local_images_paths = local_block_adjustment(
     global_image_paths_array,
     local_folder,
-    target_blocks_per_image=100,
-    debug_mode=True,
-    window_size="block",
+    number_of_blocks=100,
+    debug_mode=False,
+    window_size=(512,512),
     parallel=True,
     )
 


### PR DESCRIPTION
Fixed issue that was raised in github about edge blocks. Before, reference edge blocks means where calculated as a single value for all images, now edge blocks are unique to each image and calculated individually. Center blocks are still only calculated once to save processing time.  Replaced `tile_width_and_height_tuple` with a unified `window_size` parameter for cleaner code and consistency. Updated paths and projection handling while improving block-level processing for better performance and organization. Added enhancements to block referencing and debug outputs for clarity.