### PR TITLE
Add CLI support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ![Global and Local Matching](./images/spectralmatch.png)
 
-*spectralmatch* provides a Python library and QGIS plugin with multiple algorythms to perform Relative Radiometric Normalization (RRN). It also includes utilities for generating seamlines, cloud masks, Pseudo-Invariant Features, statistics, preprocessing, and more.
+*spectralmatch* provides a Python library, command line interface, and QGIS plugin with multiple algorythms to perform Relative Radiometric Normalization (RRN). It also includes utilities for generating seamlines, cloud masks, Pseudo-Invariant Features, statistics, preprocessing, and more.
 
 ## Features
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,33 @@
+# Command Line Interface
+
+## Installation
+The command line interface will be installed automatically when the Python library is installed. See instructions on the installation [page](https://spectralmatch.github.io/spectralmatch/installation/). Use the api reference or command --help to see options to pass into python functions.
+
+## Usage
+
+Print general help:
+
+```bash
+spectralmatch --help
+```
+
+Print help for a specific command:
+
+```bash
+spectralmatch COMMAND --help
+```
+
+Print installed version:
+
+```bash
+spectralmatch --version
+```
+
+Run a specific command:
+
+```bash
+spectralmatch COMMAND [OPTIONS]
+```
+
+## Commands
+{commands_content}

--- a/docs/create_cli.py
+++ b/docs/create_cli.py
@@ -1,0 +1,53 @@
+import inspect
+import spectralmatch
+import os
+from collections import defaultdict
+from mkdocs_gen_files import open as gen_open
+
+
+def generate_commands_section(module) -> str:
+    func_groups = defaultdict(list)
+
+    for name in getattr(module, "__all__", []):
+        func = getattr(module, name, None)
+        if callable(func):
+            doc = inspect.getdoc(func)
+            if not doc:
+                raise ValueError(f"Missing docstring for function: {name}")
+
+            mod = inspect.getmodule(func)
+            if mod and mod.__name__.startswith("spectralmatch."):
+                group_key = mod.__name__.split(".")[1]
+            elif mod and mod.__name__ == "spectralmatch":
+                group_key = os.path.splitext(os.path.basename(inspect.getfile(func)))[0]
+            else:
+                group_key = mod.__name__ if mod else "unknown"
+
+            func_groups[group_key].append((name, doc.splitlines()[0]))
+
+    # Build commands section
+    lines = [""]
+    for group in func_groups:
+        group_title = group.replace("_", " ").capitalize()
+        lines.append(f"### {group_title}\n")
+        for name, first_line in func_groups[group]:
+            lines.append(f"#### `{name}`\n{first_line.strip()}\n")
+
+    return "\n".join(lines)
+
+
+def main():
+    template_path = os.path.join("docs", "cli.md")
+    with open(template_path, "r", encoding="utf-8") as f:
+        template = f.read()
+
+    if "{commands_content}" not in template:
+        raise ValueError("Placeholder {commands_content} not found in cli.md")
+
+    commands = generate_commands_section(spectralmatch)
+    return template.replace("{commands_content}", commands)
+
+
+# Write output during mkdocs build
+with gen_open("cli.md", "w") as f:
+    f.write(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ plugins:
     - gen-files:
           scripts:
               - docs/create_llm_prompt.py
+              - docs/create_cli.py
 
 markdown_extensions:
     - attr_list
@@ -62,6 +63,7 @@ nav:
         - Create Seamlines: api/seamline.md
         - Utilities: api/utils.md
         - Statistical Figures: api/statistics.md
+    - Command Line Interface: cli.md
 
 extra_css:
     - docs/overrides/custom.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ docs = [
 [project.urls]
 "Bug Tracker" = "https://github.com/cankanoa/spectralmatch"
 "Source" = "https://github.com/cankanoa/spectralmatch"
+
+[project.scripts]
+spectralmatch = "spectralmatch.cli:main"

--- a/spectralmatch/cli.py
+++ b/spectralmatch/cli.py
@@ -1,0 +1,29 @@
+import fire
+import spectralmatch
+import inspect
+from importlib.metadata import version as get_version, PackageNotFoundError
+import sys
+
+def cli_version():
+    try:
+        print(get_version("spectralmatch"))
+    except PackageNotFoundError:
+        print("Spectralmatch (version unknown)")
+
+def build_cli():
+    class CLI:
+        """"""
+
+    for name in spectralmatch.__all__:
+        func = getattr(spectralmatch, name, None)
+        if callable(func):
+            func.__doc__ = inspect.getdoc(func) or "No description available."
+            setattr(CLI, name, staticmethod(func))
+
+    return CLI
+
+def main():
+    if "--version" in sys.argv:
+        cli_version()
+        return
+    fire.Fire(build_cli())


### PR DESCRIPTION
This commit introduces a command line interface (CLI) for the spectralMatch library, enabling users to execute commands directly from the terminal. It includes a new `spectralmatch.cli` module, CLI documentation, and integration into the project build and configuration files.